### PR TITLE
Export path to mingw root as MINGW_HOME env var and set cmake generat…

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -96,5 +96,7 @@ class MingwInstallerConan(ConanFile):
 
     def package_info(self):
         self.env_info.path.append(os.path.join(self.package_folder, "bin"))
+        self.env_info.MINGW_HOME = str(self.package_folder)
+        self.env_info.CONAN_CMAKE_GENERATOR = "MinGW Makefiles"
         self.env_info.CXX = os.path.join(self.package_folder, "bin", "g++.exe")
         self.env_info.CC = os.path.join(self.package_folder, "bin", "gcc.exe")


### PR DESCRIPTION
…ors to make this package usable outside of conan_packager, just by simply adding it to build_requires